### PR TITLE
Add a variable to allow setting the timeout on the receiver Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ redshift_dns_name | The hostname of the Redshift instance
 redshift_port | The port on which to connect to Redshift
 redshift_schema | The name of the Redshift schema to use
 controlshift_hostname | The hostname of your ControlShift instance. Likely to be something like action.myorganization.org
+receiver_timeout | The timeout for the receiving Lambda, in hundredths of a second
 
 
 ### Terraform State S3 Backend

--- a/main.tf
+++ b/main.tf
@@ -12,4 +12,5 @@ module "terraform-aws-controlshift-redshift-sync" {
   redshift_port = var.redshift_port
   redshift_schema = var.redshift_schema
   controlshift_hostname = var.controlshift_hostname
+  receiver_timeout = var.receiver_timeout
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "controlshift_hostname" {
   type        = string
   description = "The hostname of your ControlShift instance. Likely to be something like action.myorganization.org"
 }
+
+variable "receiver_timeout" {
+  default = 60
+  type        = number
+  description = "The timeout for the receiving Lambda, in seconds"
+}


### PR DESCRIPTION
Adding a variable to allow setting the timeout on the receiver Lambda, because the default of 3 seconds is not enough to retrieve large tables (the `signatures` table in particular).