### PR TITLE
Handle "character varying" type

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -5,7 +5,7 @@ require 'json'
 require 'byebug'
 
 def normalize_types(type)
-  if %w(hstore json jsonb text).include?(type)
+  if (['hstore', 'json', 'jsonb', 'text', 'character varying']).include?(type)
     'CHARACTER VARYING(max)'
   elsif %w(uuid).include?(type)
     # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003

--- a/create_tables.rb
+++ b/create_tables.rb
@@ -5,7 +5,7 @@ require 'json'
 require 'byebug'
 
 def normalize_types(type)
-  if (['hstore', 'json', 'jsonb', 'text', 'character varying']).include?(type)
+  if (['hstore', 'json', 'jsonb', 'text']).include?(type) || type.include?('character varying')
     'CHARACTER VARYING(max)'
   elsif %w(uuid).include?(type)
     # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003


### PR DESCRIPTION
If we get a column type of "character varying", make sure to use "character varying(max)" in Redshift (otherwise it will have a max length of 256).

Duplicates https://github.com/controlshift/bulk-data-example/commit/bc2cad4538cf84ed5d840b0b9ba65e323e0f6041 and https://github.com/controlshift/bulk-data-example/pull/5/commits/40dbad3b6b600557478940a9d5e92fb2c880ad98