### PR TITLE
Add secrets manager for Redshift connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 module "terraform-aws-controlshift-redshift-sync" {
   source = "git@github.com:MoveOnOrg/terraform-aws-controlshift-redshift-sync.git"
-  redshift_username = var.redshift_username
-  redshift_password = var.redshift_password
+  redshift_username = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["username"]
+  redshift_password = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["password"]
   manifest_bucket_name = var.manifest_bucket_name
   glue_scripts_bucket_name = var.glue_scripts_bucket_name
   redshift_cluster_identifier = var.redshift_cluster_identifier
@@ -11,7 +11,7 @@ module "terraform-aws-controlshift-redshift-sync" {
   success_topic_name = var.success_topic_name
   failure_topic_name = var.failure_topic_name
   aws_region = var.aws_region
-  redshift_database_name = var.redshift_database_name
+  redshift_database_name = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["dbName"]
   redshift_schema = var.redshift_schema
   controlshift_hostname = var.controlshift_hostname
   receiver_timeout = var.receiver_timeout

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret" "redshift_admin" {
+  arn = "arn:aws:secretsmanager:us-west-1:756917843633:secret:redshift-admin-FX6ihQ"
+}
+
+data "aws_secretsmanager_secret_version" "current" {
+  secret_id = data.aws_secretsmanager_secret.redshift_admin.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,21 +4,6 @@ variable "aws_region" {
   description = "The AWS Region to use. All resources will be created in this region."
 }
 
-variable "redshift_database_name" {
-  type = string
-}
-variable "redshift_dns_name" {
-  type = string
-}
-variable "redshift_port" {
-  type = string
-}
-variable "redshift_username" {
-  type        = string
-}
-variable "redshift_password" {
-  type        = string
-}
 variable "redshift_schema" {
   type  = string
   default = "public"


### PR DESCRIPTION
Instead of having the Redshift connection information as variables, it's now read automatically from AWS Secrets Manager.  This will not auto-update if the secret changes; the Terraform config will still need to be re-run.